### PR TITLE
Fix date parsing

### DIFF
--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -1,13 +1,13 @@
 import NextImage from "next/image";
 import styled from "styled-components";
 import css from "@styled-system/css";
-import { format } from "date-fns";
 import Flex from "components/Flex";
 import Box from "components/Box";
 import Tags from "components/Tags";
 import Link from "components/Link";
 import { transition } from "components/system";
 import { BlogMeta } from "layouts/BlogArticle/types";
+import { getParsedDate } from "layouts/BlogArticle";
 
 interface ArticleCardProps {
   meta: {
@@ -18,6 +18,8 @@ interface ArticleCardProps {
 
 export default function ArticleCard({ meta }: ArticleCardProps) {
   const image = meta.frontmatter.logo?.image;
+  const parsedDate = getParsedDate(meta.frontmatter.date);
+
   return (
     <StyledCard href={meta.uri} flexDirection={!!image ? "row" : "column"}>
       {!!image && (
@@ -32,7 +34,7 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
       )}
       <Flex flexDirection="column">
         <Box as="p" text="text-sm" color="darkest">
-          {format(new Date(meta.frontmatter.date), "MMM d, yyyy")}
+          {parsedDate}
         </Box>
         <Box as="p" text="text-md" color="darkest" fontWeight="bold">
           By {meta.frontmatter.author}

--- a/layouts/BlogArticle/BlogArticle.tsx
+++ b/layouts/BlogArticle/BlogArticle.tsx
@@ -46,6 +46,7 @@ export const getParsedDate = (date) => {
       // multiplying by '1000' gives us the difference in milliseconds
       initialParsedDate.getTimezoneOffset() * 60 * 1000
   );
+  // formats the date to be Month, Day Year
   return format(adjustedDate, "MMM d, yyyy");
 };
 

--- a/layouts/BlogArticle/BlogArticle.tsx
+++ b/layouts/BlogArticle/BlogArticle.tsx
@@ -34,12 +34,16 @@ interface BlogArticleProps {
 }
 
 export const getParsedDate = (date) => {
-  // date needs to be coerced into DateTime because dates can't be strings when passed to 'format'
+  // date needs to be coerced into DateTime because dates can't be of type string when passed as arg to 'format'
   const initialParsedDate = new Date(date);
   // date needs to be adjusted to take into account time zone differences
   // the time zone offset from PST is subtracted from the initial parsed date
   const adjustedDate = new Date(
+    // valueOf() returns number of milliseconds between 1 January 1970 00:00:00 UTC and the given date
     initialParsedDate.valueOf() +
+      // getTimeZoneOffset returns the time zone difference, in minutes, from current locale to UTC
+      // multiplying by '60' gives us the difference in seconds
+      // multiplying by '1000' gives us the difference in milliseconds
       initialParsedDate.getTimezoneOffset() * 60 * 1000
   );
   return format(adjustedDate, "MMM d, yyyy");

--- a/layouts/BlogArticle/BlogArticle.tsx
+++ b/layouts/BlogArticle/BlogArticle.tsx
@@ -2,7 +2,7 @@ import { MDXProvider } from "@mdx-js/react";
 import styled from "styled-components";
 import css from "@styled-system/css";
 import Drift from "components/Drift";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import NextImage from "next/image";
 import Box from "components/Box";
 import FeaturedArticleCards from "./FeaturedArticleCards";
@@ -56,6 +56,12 @@ export const BlogArticle = ({
         Boolean(article.frontmatter.logo) // filter out the post itself as well as posts without cover photo
     )
     .slice(0, 3);
+
+  const unformattedDate = new Date(date);
+  console.log(unformattedDate);
+
+  // const newDate = format(parseISO(unformattedDate), "MMM d, yyyy");
+  // console.log("newDate", newDate);
 
   return (
     <>

--- a/layouts/BlogArticle/BlogArticle.tsx
+++ b/layouts/BlogArticle/BlogArticle.tsx
@@ -2,7 +2,6 @@ import { MDXProvider } from "@mdx-js/react";
 import styled from "styled-components";
 import css from "@styled-system/css";
 import Drift from "components/Drift";
-import { format, parseISO } from "date-fns";
 import NextImage from "next/image";
 import Box from "components/Box";
 import FeaturedArticleCards from "./FeaturedArticleCards";
@@ -21,6 +20,7 @@ import { BlogMeta } from "layouts/BlogArticle/types";
 import divider from "./assets/divider.png";
 import rss from "./assets/rss.svg";
 import { components } from "./components";
+import { format } from "date-fns";
 
 interface MetaBlogArticle extends BlogMeta {
   noindex?: boolean;
@@ -33,8 +33,16 @@ interface BlogArticleProps {
   children: React.ReactNode;
 }
 
-const addUTCTime = (dateString) => {
-  return dateString.concat(" 00:00:00 GMT");
+export const getParsedDate = (date) => {
+  // date needs to be coerced into DateTime because dates can't be strings when passed to 'format'
+  const initialParsedDate = new Date(date);
+  // date needs to be adjusted to take into account time zone differences
+  // the time zone offset from PST is subtracted from the initial parsed date
+  const adjustedDate = new Date(
+    initialParsedDate.valueOf() +
+      initialParsedDate.getTimezoneOffset() * 60 * 1000
+  );
+  return format(adjustedDate, "MMM d, yyyy");
 };
 
 export const BlogArticle = ({
@@ -60,20 +68,7 @@ export const BlogArticle = ({
         Boolean(article.frontmatter.logo) // filter out the post itself as well as posts without cover photo
     )
     .slice(0, 3);
-
-  // const convertedDate = addUTCTime(date);
-
-  console.log("date", date);
-  // const newDate = new Date(date);
-  // console.log(newDate);
-  // const formatted = format(convertedDate, "MMM d, yyyy");
-  // console.log(formatted);
-
-  // const x = parseISO(date);
-  // console.log(x);
-
-  // const newDate = format(x, "MMM d, yyyy");
-  // console.log("newDate", newDate);
+  const parsedDate = getParsedDate(date);
 
   return (
     <>
@@ -101,7 +96,7 @@ export const BlogArticle = ({
               mt="2"
               mb={[6, 11]}
             >
-              {date} by {author}
+              {parsedDate} by {author}
             </Box>
             {logo && (
               <NextImage

--- a/layouts/BlogArticle/BlogArticle.tsx
+++ b/layouts/BlogArticle/BlogArticle.tsx
@@ -33,6 +33,10 @@ interface BlogArticleProps {
   children: React.ReactNode;
 }
 
+const addUTCTime = (dateString) => {
+  return dateString.concat(" 00:00:00 GMT");
+};
+
 export const BlogArticle = ({
   children,
   meta: {
@@ -57,10 +61,18 @@ export const BlogArticle = ({
     )
     .slice(0, 3);
 
-  const unformattedDate = new Date(date);
-  console.log(unformattedDate);
+  // const convertedDate = addUTCTime(date);
 
-  // const newDate = format(parseISO(unformattedDate), "MMM d, yyyy");
+  console.log("date", date);
+  // const newDate = new Date(date);
+  // console.log(newDate);
+  // const formatted = format(convertedDate, "MMM d, yyyy");
+  // console.log(formatted);
+
+  // const x = parseISO(date);
+  // console.log(x);
+
+  // const newDate = format(x, "MMM d, yyyy");
   // console.log("newDate", newDate);
 
   return (
@@ -89,7 +101,7 @@ export const BlogArticle = ({
               mt="2"
               mb={[6, 11]}
             >
-              {format(new Date(date), "MMM d, yyyy")} by {author}
+              {date} by {author}
             </Box>
             {logo && (
               <NextImage

--- a/layouts/BlogArticle/index.ts
+++ b/layouts/BlogArticle/index.ts
@@ -1,1 +1,2 @@
 export { BlogArticle as default } from "./BlogArticle";
+export { getParsedDate } from "./BlogArticle";


### PR DESCRIPTION
* Fixes [this Asana task](https://app.asana.com/0/0/1201931847138508) / https://github.com/gravitational/blog/issues/48

## Previews
* [post in /blog](https://blog-git-sandy-date-gravitational.vercel.app/blog/what-is-kubectl/)
* [post in /web](https://goteleport.com/blog/what-is-kubectl/)

## Issue

![image](https://user-images.githubusercontent.com/60662264/157545883-ca2134b1-2f5e-4ac8-8449-83f468f07e5d.png)

Previously blog posts were showing up as a day off from the actual date. This is because `new Date()` returns the date in UTC GTM format, which accounts for the offset. Dates needed to be adjusted by taking into account our timezone.

## Solution

This was fixed by parsing the date using the following:
```
export const getParsedDate = (date) => {
  const initialParsedDate = new Date(date);

  const adjustedDate = new Date(
    initialParsedDate.valueOf() + initialParsedDate.getTimezoneOffset() * 60 * 1000
  );
  return format(adjustedDate, "MMM d, yyyy");
};
```

## Parsing Steps
* First the date string is converted to DateTime type
* Next a new `Date` is created by passing the addition of the following
     * `initalParsedDate.valueOf()`
          *  `valueOf()` returns number of milliseconds between 1 January 1970 00:00:00 UTC and the `initialParsedDate`
     * `initialParsedDate.getTimezoneOffset() * 60 * 1000`
          *  `getTimezoneOffset()` returns the time zone difference, in minutes, from the current locale and UTC
          * `* 60` gives us the difference in seconds
          * `* 1000` gives us the difference in milliseconds
* Finally, the `adjustedDate` is formatted to be in the style of "Month day, year"

## Demo of parsing dates this way

<img width="699" alt="Screen Shot 2022-03-09 at 1 54 02 PM" src="https://user-images.githubusercontent.com/60662264/157552552-cc3e2c3c-7682-40f0-8743-5f17b0fd90f7.png">
