### PR TITLE
Adds trailing slash for blog index in sitemap

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -70,7 +70,7 @@ export const getBlogPaths = () => {
       (path) =>
         !ignorePages.some((regexp) => regexp.test(path)) && path !== blogIndex
     );
-  paths.unshift(pagesRoot);
+  paths.unshift(pagesRoot + "/");
   return paths.map((path) => getURIFromPath(path));
 };
 


### PR DESCRIPTION
Adds a trailing slash when the root is generated in the sitemap: 
![Screen Shot 2022-03-10 at 8 58 09 AM](https://user-images.githubusercontent.com/73362670/157726033-bc23e0e7-08ff-451d-b00a-8a93a92bcb4a.png)
Becomes: 
![Screen Shot 2022-03-10 at 8 58 32 AM](https://user-images.githubusercontent.com/73362670/157726048-a33badb9-0685-4e36-b98e-0b8ff0c71625.png)

