### PR TITLE
Refactor ArticleCard to be accessible, clear console errors related to it

### DIFF
--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -21,7 +21,7 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
   const parsedDate = getParsedDate(meta.frontmatter.date);
 
   return (
-    <OuterContainer style={{ flexDirection: image ? "row" : "column" }}>
+    <OuterContainer flexDirection={!!image ? "row" : "column"}>
       {image && (
         <ImageContainer>
           <NextImage
@@ -32,38 +32,31 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
           />
         </ImageContainer>
       )}
-      <TextContainer>
-        <DateContainer text="text-sm">{parsedDate}</DateContainer>
-
-        <AuthorContainer text="text-md">
-          By {meta.frontmatter.author}
-        </AuthorContainer>
-
-        <ArticleTitleContainer>
+      <Text>
+        <Date text="text-sm">{parsedDate}</Date>
+        <Author text="text-md">By {meta.frontmatter.author}</Author>
+        <Title>
           <ArticleLink href={meta.uri}>
             {meta.frontmatter.articleTitle}
           </ArticleLink>
-        </ArticleTitleContainer>
-
-        <DescriptionContainer>
-          {meta.frontmatter.description}
-        </DescriptionContainer>
+        </Title>
+        <Description>{meta.frontmatter.description}</Description>
         {!!meta.frontmatter.tags.length && (
           <StyledTags tags={meta.frontmatter.tags} size="sm" />
         )}
-      </TextContainer>
+      </Text>
     </OuterContainer>
   );
 }
 
-const AuthorContainer = styled(Box)(
+const Author = styled(Box)(
   css({
     color: "darkest",
     fontWeight: "bold",
   })
 );
 
-const DateContainer = styled(Box)(
+const Date = styled(Box)(
   css({
     color: "darkest",
   })
@@ -79,7 +72,7 @@ const StyledTags = styled(Tags)(
   })
 );
 
-const TextContainer = styled(Flex)(
+const Text = styled(Flex)(
   css({
     flexDirection: "column",
   })
@@ -152,7 +145,7 @@ const ImageContainer = styled("div")(
   })
 );
 
-const ArticleTitleContainer = styled(Box)(
+const Title = styled(Box)(
   css({
     fontSize: "header-3",
     lineHeight: "lg",
@@ -173,7 +166,7 @@ const ArticleTitleContainer = styled(Box)(
   })
 );
 
-const DescriptionContainer = styled(Box)(
+const Description = styled(Box)(
   css({
     fontSize: "text-lg",
     lineHeight: "lg",

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -19,51 +19,64 @@ interface ArticleCardProps {
 export default function ArticleCard({ meta }: ArticleCardProps) {
   const image = meta.frontmatter.logo?.image;
   return (
-    <StyledCard style={{ flexDirection: image ? "row" : "column" }}>
+    <OuterContainer style={{ flexDirection: image ? "row" : "column" }}>
       {image && (
-        <StyledWrapperImage>
+        <ImageContainer>
           <NextImage
             src={image}
             alt={meta.frontmatter.articleTitle}
             layout="fill"
             objectFit="cover"
           />
-        </StyledWrapperImage>
+        </ImageContainer>
       )}
-      <Flex flexDirection="column">
+      <TextContainer>
         <Box as="p" text="text-sm" color="darkest">
           {format(new Date(meta.frontmatter.date), "MMM d, yyyy")}
         </Box>
         <Box as="p" text="text-md" color="darkest" fontWeight="bold">
           By {meta.frontmatter.author}
         </Box>
-        <StyledArticleTitle as="h3">
-          <StyledArticleLink href={meta.uri}>
+
+        <ArticleTitleContainer>
+          <ArticleLink href={meta.uri}>
             {meta.frontmatter.articleTitle}
-          </StyledArticleLink>
-        </StyledArticleTitle>
-        <StyledDescription as="p">
+          </ArticleLink>
+        </ArticleTitleContainer>
+
+        <DescriptionContainer>
           {meta.frontmatter.description}
-        </StyledDescription>
+        </DescriptionContainer>
         {!!meta.frontmatter.tags.length && (
-          <Tags
-            tags={meta.frontmatter.tags}
-            size="sm"
-            mt="auto"
-            pt="3"
-            position="relative"
-          />
+          <StyledTags tags={meta.frontmatter.tags} size="sm" />
         )}
-      </Flex>
-    </StyledCard>
+      </TextContainer>
+    </OuterContainer>
   );
 }
 
-const StyledArticleLink = styled("a")(
+const StyledTags = styled(Tags)(
+  css({
+    mt: "auto",
+    pt: 3,
+    // position relative is used on the Tags link in order for Tags to be clickable
+    // over ArticleLink (which makes the whole card clickable)
+    position: "relative",
+  })
+);
+
+const TextContainer = styled(Flex)(
+  css({
+    flexDirection: "column",
+  })
+);
+
+const ArticleLink = styled(Link)(
   css({
     textDecoration: "none",
     color: "dark-purple",
 
+    // psuedo-content :after is used to make the entire card clickable
     "&:after": {
       content: "''",
       position: "absolute",
@@ -75,20 +88,15 @@ const StyledArticleLink = styled("a")(
   })
 );
 
-const StyledCard = styled("div")(
+const OuterContainer = styled(Flex)(
   css({
-    display: "flex",
     position: "relative",
-    textDecoration: "none",
     ml: -4,
     py: 5,
     px: 4,
     "&::after": {
-      position: "absolute",
-      bottom: 0,
       left: 4,
       display: "block",
-      content: ["none", '""'],
       width: "840px",
       height: "1px",
       backgroundColor: "lightest-gray",
@@ -104,7 +112,7 @@ const StyledCard = styled("div")(
   })
 );
 
-const StyledWrapperImage = styled("div")(
+const ImageContainer = styled("div")(
   css({
     position: "relative",
     flexShrink: 0,
@@ -130,7 +138,7 @@ const StyledWrapperImage = styled("div")(
   })
 );
 
-const StyledArticleTitle = styled(Box)(
+const ArticleTitleContainer = styled(Box)(
   css({
     fontSize: "header-3",
     lineHeight: "lg",
@@ -151,7 +159,7 @@ const StyledArticleTitle = styled(Box)(
   })
 );
 
-const StyledDescription = styled(Box)(
+const DescriptionContainer = styled(Box)(
   css({
     fontSize: "text-lg",
     lineHeight: "lg",

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -19,12 +19,12 @@ interface ArticleCardProps {
 export default function ArticleCard({ meta }: ArticleCardProps) {
   const image = meta.frontmatter.logo?.image;
   return (
-    <StyledCard href={meta.uri} flexDirection={!!image ? "row" : "column"}>
-      {!!image && (
+    <StyledCard style={{ flexDirection: image ? "row" : "column" }}>
+      {image && (
         <StyledWrapperImage>
           <NextImage
             src={image}
-            alt="article image"
+            alt={meta.frontmatter.articleTitle}
             layout="fill"
             objectFit="cover"
           />
@@ -38,20 +38,44 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
           By {meta.frontmatter.author}
         </Box>
         <StyledArticleTitle as="h3">
-          {meta.frontmatter.articleTitle}
+          <StyledArticleLink href={meta.uri}>
+            {meta.frontmatter.articleTitle}
+          </StyledArticleLink>
         </StyledArticleTitle>
         <StyledDescription as="p">
           {meta.frontmatter.description}
         </StyledDescription>
         {!!meta.frontmatter.tags.length && (
-          <Tags tags={meta.frontmatter.tags} size="sm" mt="auto" pt="3" />
+          <Tags
+            tags={meta.frontmatter.tags}
+            size="sm"
+            mt="auto"
+            pt="3"
+            position="relative"
+          />
         )}
       </Flex>
     </StyledCard>
   );
 }
 
-const StyledCard = styled(Link)(
+const StyledArticleLink = styled("a")(
+  css({
+    textDecoration: "none",
+    color: "dark-purple",
+
+    "&:after": {
+      content: "''",
+      position: "absolute",
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    },
+  })
+);
+
+const StyledCard = styled("div")(
   css({
     display: "flex",
     position: "relative",

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -24,19 +24,20 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
         <ImageContainer>
           <NextImage
             src={image}
-            alt={meta.frontmatter.articleTitle}
+            alt={meta.frontmatter.logo.alt}
             layout="fill"
             objectFit="cover"
           />
         </ImageContainer>
       )}
       <TextContainer>
-        <Box as="p" text="text-sm" color="darkest">
+        <DateContainer text="text-sm">
           {format(new Date(meta.frontmatter.date), "MMM d, yyyy")}
-        </Box>
-        <Box as="p" text="text-md" color="darkest" fontWeight="bold">
+        </DateContainer>
+
+        <AuthorContainer text="text-md">
           By {meta.frontmatter.author}
-        </Box>
+        </AuthorContainer>
 
         <ArticleTitleContainer>
           <ArticleLink href={meta.uri}>
@@ -55,13 +56,26 @@ export default function ArticleCard({ meta }: ArticleCardProps) {
   );
 }
 
+const AuthorContainer = styled(Box)(
+  css({
+    color: "darkest",
+    fontWeight: "bold",
+  })
+);
+
+const DateContainer = styled(Box)(
+  css({
+    color: "darkest",
+  })
+);
+
 const StyledTags = styled(Tags)(
   css({
     mt: "auto",
-    pt: 3,
     // position relative is used on the Tags link in order for Tags to be clickable
     // over ArticleLink (which makes the whole card clickable)
     position: "relative",
+    pt: 3,
   })
 );
 
@@ -76,14 +90,14 @@ const ArticleLink = styled(Link)(
     textDecoration: "none",
     color: "dark-purple",
 
-    // psuedo-content :after is used to make the entire card clickable
+    // pseudo-content :after is used to make the entire card clickable
     "&:after": {
-      content: "''",
-      position: "absolute",
-      top: 0,
-      left: 0,
       bottom: 0,
+      content: "''",
+      left: 0,
+      position: "absolute",
       right: 0,
+      top: 0,
     },
   })
 );

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -61,7 +61,7 @@ const StyledUL = styled("ul")(
   all
 );
 
-const StyledLink = styled("button")(
+const StyledLink = styled(Link)(
   css({
     display: "block",
     color: "darkest",

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -61,7 +61,7 @@ const StyledUL = styled("ul")(
   all
 );
 
-const StyledLink = styled(Link)(
+const StyledLink = styled("button")(
   css({
     display: "block",
     color: "darkest",


### PR DESCRIPTION
## Preview

* [new index page](https://blog-git-sandy-console-gravitational.vercel.app/blog/)
* [current live index](https://teleport-blog-next.vercel.app/blog/)

## Issue

* Console warnings about having  an `<a>` as a descendant of another `<a>`
* This was due to using a `<Link>` as the outer container of `<ArticleCard>` while also having an inner link for `<Tags>` at the bottom of the container

## Solution
* Instead of having a`<Link>` as the parent component of `<Tags>`, I made them sibling components
* Maintained the functionality of the entire card being clickable using pseudo-selectors (more information [here](https://inclusive-components.design/cards/))
* All links are now tab-focusable by screen readers

## Before

<img width="1108" alt="Screen Shot 2022-03-09 at 4 02 58 PM" src="https://user-images.githubusercontent.com/60662264/157764411-4f3cb07e-2100-4558-961c-c8b5d40d51b4.png">

## After

<img width="1428" alt="Screen Shot 2022-03-10 at 2 41 14 PM" src="https://user-images.githubusercontent.com/60662264/157767118-5e4a8f4a-7f62-4b42-ac30-65ada202da2e.png">
